### PR TITLE
Add simple car cost function

### DIFF
--- a/localisation/src/survey/calculations/__tests__/carcost.test.ts
+++ b/localisation/src/survey/calculations/__tests__/carcost.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+
+import { carCostAverageCaa, CarCategory, CarEngine } from '../carcost';
+
+describe('carCostAverageCaa', () => {
+    describe('valid combinations', () => {
+        it('should return correct cost for PassengerCar + Electric', () => {
+            expect(carCostAverageCaa(CarCategory.PassengerCar, CarEngine.Electric)).toBeCloseTo(5947.69);
+        });
+
+        it('should return correct cost for PassengerCar + PluginHybrid', () => {
+            expect(carCostAverageCaa(CarCategory.PassengerCar, CarEngine.PluginHybrid)).toBeCloseTo(7484.73);
+        });
+
+        it('should return correct cost for PassengerCar + Hybrid', () => {
+            expect(carCostAverageCaa(CarCategory.PassengerCar, CarEngine.Hybrid)).toBeCloseTo(7539.17);
+        });
+
+        it('should return correct cost for PassengerCar + Gas', () => {
+            expect(carCostAverageCaa(CarCategory.PassengerCar, CarEngine.Gas)).toBeCloseTo(9399.17);
+        });
+
+        it('should return correct cost for LuxuryCar + Gas', () => {
+            expect(carCostAverageCaa(CarCategory.LuxuryCar, CarEngine.Gas)).toBeCloseTo(16252.59);
+        });
+
+        it('should return correct cost for Pickup + Electric', () => {
+            expect(carCostAverageCaa(CarCategory.Pickup, CarEngine.Electric)).toBeCloseTo(10440.29);
+        });
+
+        it('should return correct cost for Suv + PluginHybrid', () => {
+            expect(carCostAverageCaa(CarCategory.Suv, CarEngine.PluginHybrid)).toBeCloseTo(7175.75);
+        });
+    });
+
+    describe('invalid combinations', () => {
+        it('should throw error for Pickup + PluginHybrid (no data available)', () => {
+            expect(() => carCostAverageCaa(CarCategory.Pickup, CarEngine.PluginHybrid))
+                .toThrow('No data available for pickup + pluginHybrid');
+        });
+    });
+});

--- a/localisation/src/survey/calculations/carcost.ts
+++ b/localisation/src/survey/calculations/carcost.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+export enum CarCategory {
+    PassengerCar = 'passengerCar',
+    LuxuryCar = 'luxuryCar',
+    Pickup = 'pickup',
+    Suv = 'suv'
+}
+
+export enum CarEngine {
+    Electric = 'electric',
+    PluginHybrid = 'pluginHybrid',
+    Hybrid = 'hybrid',
+    Gas = 'gas'
+}
+
+/* Calculated average from CAA data. Will need to be done properly
+   Was scraped from their website. Average were calculated from a subset of the
+   data taken at an unknown date. An AI agent parsed the 2019 et 2022 model list
+   and generated these averages.
+ */
+export const averageAnnualCarCost: Record<CarCategory, Partial<Record<CarEngine, number>>> = {
+    [CarCategory.PassengerCar]: {
+        [CarEngine.Electric]: 5947.69,
+        [CarEngine.PluginHybrid]: 7484.73,
+        [CarEngine.Hybrid]: 7539.17,
+        [CarEngine.Gas]: 9399.17
+    },
+    [CarCategory.LuxuryCar]: {
+        [CarEngine.Electric]: 13060.87,
+        [CarEngine.PluginHybrid]: 15433.43,
+        [CarEngine.Hybrid]: 11478.78,
+        [CarEngine.Gas]: 16252.59
+    },
+    [CarCategory.Pickup]: {
+        [CarEngine.Electric]: 10440.29,
+        [CarEngine.Hybrid]: 13034.54,
+        [CarEngine.Gas]: 11915.5
+    },
+    [CarCategory.Suv]: {
+        [CarEngine.Electric]: 6432.82,
+        [CarEngine.PluginHybrid]: 7175.75,
+        [CarEngine.Hybrid]: 7831.03,
+        [CarEngine.Gas]: 9907.93
+    }
+};
+
+/* Compute car cost based on average per type. This is based on data from CAA.
+
+   We consider engine type (electric, hybrid, gas, etc) and common types
+
+   @return {number} Annual cost of the vehicle
+ */
+export function carCostAverageCaa(category: CarCategory, engine: CarEngine): number {
+    const cost = averageAnnualCarCost[category]?.[engine];
+    if (cost === undefined) {
+        // TODO Evaluate if we would prefer instead to fall back on the gas engine for that category
+        throw new Error(`No data available for ${category} + ${engine}`);
+    }
+    return cost;
+}


### PR DESCRIPTION
Based on averages from CAA's data. We define average from category (passenger car, luxury car, pickup, SUV) and by engine (gas, electric, hybrid, plugin hybrid).

Add a simple unit test for validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vehicle cost lookup providing average annual car cost estimates for multiple vehicle categories and engine types.

* **Tests**
  * Added tests validating cost estimates across supported category/engine combinations and confirming clear error handling for unsupported configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->