### PR TITLE
result map: switch the home icon color to better map polygons

### DIFF
--- a/localisation/src/survey/sections/results/customWidgets.ts
+++ b/localisation/src/survey/sections/results/customWidgets.ts
@@ -57,9 +57,9 @@ export const comparisonMap: InfoMapWidgetConfig = {
             // Use red icon for first visible address, green for second visible address, default for others
             let iconUrl: string;
             if (addressIndex === 0) {
-                iconUrl = '/dist/icons/activities/home/home-marker_round_red.svg';
-            } else if (addressIndex === 1) {
                 iconUrl = '/dist/icons/activities/home/home-marker_round_green.svg';
+            } else if (addressIndex === 1) {
+                iconUrl = '/dist/icons/activities/home/home-marker_round_red.svg';
             } else {
                 iconUrl = getActivityMarkerIcon('home');
             }


### PR DESCRIPTION
The green home icon goes with the green-ish polygon, while the red one with the purplish one.