### PR TITLE
Fix navigation

### DIFF
--- a/localisation/src/survey/sections/addresses/sectionConfigs.ts
+++ b/localisation/src/survey/sections/addresses/sectionConfigs.ts
@@ -33,7 +33,7 @@ export const sectionConfig: SectionConfig = {
             ? isSectionCompleted({ interview, sectionName: 'household' })
             : isSectionCompleted({ interview, sectionName: previousSectionName });
     },
-    // Allow to click on the section menu
+    // Flag the section as completed or not
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
     }

--- a/localisation/src/survey/sections/cars/sectionConfigs.ts
+++ b/localisation/src/survey/sections/cars/sectionConfigs.ts
@@ -26,13 +26,15 @@ export const sectionConfig: SectionConfig = {
     widgets: widgetsNames,
     // Do some actions before the section is loaded
     preload: customPreload,
-    // Allow to click on the section menu
+    // Allow to click on the section menu. If the number of cars is zero, disable clicking on it.
     enableConditional: function (interview) {
-        return isSectionCompleted({ interview, sectionName: previousSectionName });
+        const carNumber = getResponse(interview, 'household.carNumber', 0) as number;
+        return isSectionCompleted({ interview, sectionName: previousSectionName }) && carNumber !== 0;
     },
-    // Allow to click on the section menu
+    // Flag the section as completed or not. If the number of cars is zero, mark is as completed so the navigation works properly for subsequent sections.
     completionConditional: function (interview) {
-        return isSectionCompleted({ interview, sectionName: currentSectionName });
+        const carNumber = getResponse(interview, 'household.carNumber', 0) as number;
+        return carNumber === 0 || isSectionCompleted({ interview, sectionName: currentSectionName });
     },
     // Skip this section if the number of cars is zero
     isSectionVisible: (interview, _iterationContext) => {

--- a/localisation/src/survey/sections/destinations/sectionConfigs.ts
+++ b/localisation/src/survey/sections/destinations/sectionConfigs.ts
@@ -29,7 +29,7 @@ export const sectionConfig: SectionConfig = {
     enableConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: previousSectionName });
     },
-    // Allow to click on the section menu
+    // Flag the section as completed or not
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
     }

--- a/localisation/src/survey/sections/home/sectionConfigs.ts
+++ b/localisation/src/survey/sections/home/sectionConfigs.ts
@@ -27,7 +27,7 @@ export const sectionConfig: SectionConfig = {
     preload: customPreload,
     // Allow to click on the section menu
     enableConditional: true,
-    // Allow to click on the section menu
+    // Flag the section as completed or not
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
     }

--- a/localisation/src/survey/sections/household/sectionConfigs.ts
+++ b/localisation/src/survey/sections/household/sectionConfigs.ts
@@ -29,7 +29,7 @@ export const sectionConfig: SectionConfig = {
     enableConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: previousSectionName });
     },
-    // Allow to click on the section menu
+    // Flag the section as completed or not
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
     }

--- a/localisation/src/survey/sections/results/sectionConfigs.ts
+++ b/localisation/src/survey/sections/results/sectionConfigs.ts
@@ -30,7 +30,7 @@ export const sectionConfig: SectionConfig = {
     enableConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: previousSectionName });
     },
-    // Allow to click on the section menu
+    // Flag the section as completed or not
     completionConditional: function (interview) {
         return isSectionCompleted({ interview, sectionName: currentSectionName });
     }


### PR DESCRIPTION
Fixes a bug related to the logic of the cars section. The section is skipped if the number of cars entered is 0, however this meant that the section is never marked as completed in that case, and the subsequents sections are greyed out and unskippable in the nav bar. This commit changes the logic to mark the cars section as complete if there are 0 cars. Also changes some generator made comments in the section configs that are incorrect. Fix: #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved survey section validation logic to ensure vehicle section navigation and completion status are properly determined based on household vehicle count.

* **Documentation**
  * Updated and clarified section completion comments across multiple survey sections to better describe their purpose in tracking completion progress.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->