### PR TITLE
results: initialize to objects with _uuid instead of `null`

### DIFF
--- a/localisation/src/survey/calculations/__tests__/routingAndAccessibility.test.ts
+++ b/localisation/src/survey/calculations/__tests__/routingAndAccessibility.test.ts
@@ -9,6 +9,7 @@ import { getAccessibilityMapFromAddress, getRoutingFromAddressToDestination } fr
 import { Address, Destination } from '../../common/types';
 import * as routing from 'evolution-backend/lib/services/routing';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
+import _ from 'lodash';
 
 // Mock the routing module
 jest.mock('evolution-backend/lib/services/routing', () => ({
@@ -450,10 +451,10 @@ describe('getRoutingFromAddressToDestination', () => {
             const result = await getRoutingFromAddressToDestination(address, destination);
 
             expect(result).not.toBeNull();
-            expect(result?.resultsByMode.walking).not.toBeNull();
-            expect(result?.resultsByMode.cycling).toBeNull();
-            expect(result?.resultsByMode.driving).toBeNull();
-            expect(result?.resultsByMode.transit).not.toBeNull();
+            expect(result?.resultsByMode.walking).toEqual({ _uuid: 'walking', _sequence: 1, distanceMeters: 1000, travelTimeSeconds: 720 });
+            expect(result?.resultsByMode.cycling).toEqual({ _uuid: 'cycling' });
+            expect(result?.resultsByMode.driving).toEqual({ _uuid: 'driving' });
+            expect(result?.resultsByMode.transit).toEqual({ _uuid: 'transit', _sequence: 0, distanceMeters: 1300, travelTimeSeconds: 600 });
         });
 
         it('should handle when all modes fail', async () => {
@@ -479,10 +480,10 @@ describe('getRoutingFromAddressToDestination', () => {
             const result = await getRoutingFromAddressToDestination(address, destination);
 
             expect(result).not.toBeNull();
-            expect(result?.resultsByMode.walking).toBeNull();
-            expect(result?.resultsByMode.cycling).toBeNull();
-            expect(result?.resultsByMode.driving).toBeNull();
-            expect(result?.resultsByMode.transit).toBeNull();
+            expect(result?.resultsByMode.walking).toEqual({ _uuid: 'walking' });
+            expect(result?.resultsByMode.cycling).toEqual({ _uuid: 'cycling' });
+            expect(result?.resultsByMode.driving).toEqual({ _uuid: 'driving' });
+            expect(result?.resultsByMode.transit).toEqual({ _uuid: 'transit' });
         });
     });
 

--- a/localisation/src/survey/calculations/routingAndAccessibility.ts
+++ b/localisation/src/survey/calculations/routingAndAccessibility.ts
@@ -79,10 +79,14 @@ export const getRoutingFromAddressToDestination = async (
             transitScenario: scenario
         });
         const results = {
-            walking: null,
-            cycling: null,
-            driving: null,
-            transit: null
+            // FIXME Initialized with a _uuid parameter just to satisfy the
+            // Evolution framework, but if the results display is moved out of
+            // Evolution, set to `null` by default instead to clarify that the
+            // values are not available
+            walking: { _uuid: 'walking' },
+            cycling: { _uuid: 'cycling' },
+            driving: { _uuid: 'driving' },
+            transit: { _uuid: 'transit' }
         } as RoutingByModeDistanceAndTime['resultsByMode'];
         calculationModes.forEach((mode, index) => {
             const modeTimeAndDistance = timeAndDistances[mode];


### PR DESCRIPTION
fixes #60

For now, since results use the Evolution framework grouped object for display, we need to initialize the results to an object with a `_uuid` field instead of `null`. This avoids redirection to the error page when there is no transit routing found for address/destination pairs.

As the results page evolves, we may revert to using `null` to describe a no routing if the results stop using Evolution widgets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted routing result initialization for improved framework compatibility; missing or unavailable travel modes now present as minimal placeholders rather than null.

* **Tests**
  * Updated tests to reflect the new result shape for routing and accessibility outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->