### PR TITLE
Make group titles/headings darker.

### DIFF
--- a/localisation/src/styles/common-styles.scss
+++ b/localisation/src/styles/common-styles.scss
@@ -328,3 +328,14 @@ details summary {
 .survey-trip-item.survey-trip-item-selected.survey-trip-item-mode-icons {
     border-bottom: 1px solid rgba(7, 67, 171, 0.6);
 }
+
+.survey {
+    h2 {
+        font-weight: 500;
+        color: rgba(0, 0, 0, 1.0);
+    }
+
+    h3 {
+        color: rgba(0, 0, 0, 1.0);
+    }
+}


### PR DESCRIPTION
Make the title of the grouped objects darker and with thicker letters, and the name of individual objects darker, to make them easier to read. Fix: #32
<img width="1106" height="282" alt="Screenshot from 2026-01-28 10-00-53" src="https://github.com/user-attachments/assets/44f0877f-212c-4f18-b5d9-389907e440c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated survey block styling to standardize heading appearance and typography for h2 and h3 levels.
  * Improves visual consistency and readability across survey sections, ensuring headings render with clearer weight and color contrast.
  * Presentation-only change; no behavioral or functional changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->