### PR TITLE
accessibility map: get results for transit for 15, 30 and 45 minutes

### DIFF
--- a/localisation/src/survey/calculations/index.ts
+++ b/localisation/src/survey/calculations/index.ts
@@ -1,6 +1,11 @@
 import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
-import { Address, CalculationResults, RoutingByModeDistanceAndTime } from '../common/types';
+import type {
+    Address,
+    AddressAccessibilityMapsDurations,
+    CalculationResults,
+    RoutingByModeDistanceAndTime
+} from '../common/types';
 import { mortgageMonthlyPayment } from './mortgage';
 import { getResponse } from 'evolution-common/lib/utils/helpers';
 import { getAccessibilityMapFromAddress, getRoutingFromAddressToDestination } from './routingAndAccessibility';
@@ -128,7 +133,7 @@ export const calculateAccessibilityAndRouting = async (
     address: Address,
     interview: InterviewAttributes
 ): Promise<{
-    accessibilityMap: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | null;
+    accessibilityMap: AddressAccessibilityMapsDurations | null;
     routingTimeDistances: { [destinationUuid: string]: RoutingByModeDistanceAndTime | null } | null;
 }> => {
     // Make sure there is a scenario defined, otherwise, do a quick return

--- a/localisation/src/survey/common/types.ts
+++ b/localisation/src/survey/common/types.ts
@@ -25,10 +25,16 @@ export type Address = {
     // Monthly utilities cost
     utilitiesMonthly?: number;
     monthlyCost?: CalculationResults;
-    accessibilityMap?: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> | null;
+    accessibilityMap?: AddressAccessibilityMapsDurations | null;
     routingTimeDistances?: {
         [destinationUuid: string]: RoutingByModeDistanceAndTime | null;
     } | null;
+};
+
+export type AddressAccessibilityMapsDurations = {
+    duration15Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
+    duration30Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
+    duration45Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
 };
 
 export type TimeAndDistance = {

--- a/localisation/src/survey/sections/results/customWidgets.ts
+++ b/localisation/src/survey/sections/results/customWidgets.ts
@@ -67,16 +67,16 @@ export const comparisonMap: InfoMapWidgetConfig = {
             addressGeography.properties!.sequence = address._sequence;
             pointGeographies.push(addressGeography);
 
-            if (address.accessibilityMap) {
-                const accessibilityMapPolygons = address.accessibilityMap.features.map((feature) => ({
-                    ...feature,
+            if (address.accessibilityMap?.duration30Minutes) {
+                const accessibilityMapPolygon = {
+                    ...address.accessibilityMap.duration30Minutes,
                     properties: {
-                        ...(feature.properties || {}),
+                        ...(address.accessibilityMap.duration30Minutes.properties || {}),
                         strokeColor: colorPalette[addressIndex % colorPalette.length],
                         fillColor: colorPalette[addressIndex % colorPalette.length]
                     }
-                }));
-                polygonGeographies.push(...accessibilityMapPolygons);
+                };
+                polygonGeographies.push(accessibilityMapPolygon);
             }
             addressIndex++;
         }

--- a/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
+++ b/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
@@ -7,7 +7,7 @@
 
 import serverFieldUpdate from '../serverFieldUpdate';
 import { UserInterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
-import { Address } from '../../common/types';
+import { Address, AddressAccessibilityMapsDurations } from '../../common/types';
 import * as calculations from '../../calculations';
 
 // Mock the calculations module
@@ -26,28 +26,27 @@ const mockCalculateAccessibilityAndRouting = calculations.calculateAccessibility
 describe('serverFieldUpdate - _sections._actions callback', () => {
     const sectionsActionsCallback = serverFieldUpdate.find(callback => callback.field === '_sections._actions')!;
 
-    const mockAccessibilityMap: GeoJSON.FeatureCollection<GeoJSON.MultiPolygon> = {
-        type: 'FeatureCollection',
-        features: [
-            {
-                type: 'Feature',
-                geometry: {
-                    type: 'MultiPolygon',
-                    coordinates: [
+    const mockAccessibilityMap: AddressAccessibilityMapsDurations = {
+        duration15Minutes: null,
+        duration30Minutes: {
+            type: 'Feature',
+            geometry: {
+                type: 'MultiPolygon',
+                coordinates: [
+                    [
                         [
-                            [
-                                [-73.51, 45.51],
-                                [-73.49, 45.51],
-                                [-73.49, 45.49],
-                                [-73.51, 45.49],
-                                [-73.51, 45.51]
-                            ]
+                            [-73.51, 45.51],
+                            [-73.49, 45.51],
+                            [-73.49, 45.49],
+                            [-73.51, 45.49],
+                            [-73.51, 45.51]
                         ]
                     ]
-                },
-                properties: {}
-            }
-        ]
+                ]
+            },
+            properties: {}
+        },
+        duration45Minutes: null
     };
     const mockRoutingTimeDistances = {
         'destination-uuid-1': {

--- a/localisation/src/survey/server/serverFieldUpdate.ts
+++ b/localisation/src/survey/server/serverFieldUpdate.ts
@@ -2,6 +2,7 @@ import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire
 import { getAddressesArray } from '../common/customHelpers';
 import { calculateAccessibilityAndRouting, calculateMonthlyCost } from '../calculations';
 
+// FIXME Add callbacks to invalidate results when geographies change and calculate results only on demand
 export default [
     {
         field: '_sections._actions',


### PR DESCRIPTION
part of #20

This updates the type of the accessibility map results, where we have fields for each requested duration. Also the query to the Transition API now asks for 3 polygons in a 45 minutes range, which will return results for 15, 30 and 45 minutes.

Currently, the UI keeps the 30 minutes polygon in the display, but later PRs can dynamically change the polygon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Accessibility map data reorganized to return separate 15/30/45-minute results and surface the 30-minute polygon where applicable for results display.

* **Tests**
  * Updated test suites and mocks to validate the new duration-based accessibility map shape, including partial/missing-duration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->