### PR TITLE
accessibility maps: support other modes than transit

### DIFF
--- a/localisation/config.js
+++ b/localisation/config.js
@@ -46,6 +46,7 @@ module.exports = {
     trRoutingScenarios: {
         SE: '6fff51a9-b6d9-464e-bf2b-eeae574ac75e'
     },
+    emptyScenarioForSimpleModes: '7564af29-f653-4378-8499-6ba3cfa5c462',
     
     detectLanguage: false,
     detectLanguageFromUrl: true,

--- a/localisation/src/survey/calculations/routingAndAccessibility.ts
+++ b/localisation/src/survey/calculations/routingAndAccessibility.ts
@@ -6,25 +6,33 @@ import type {
     Destination,
     AddressAccessibilityMapsDurations
 } from '../common/types';
-import { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import type { RoutingOrTransitMode } from 'chaire-lib-common/lib/config/routingModes';
+import type {
+    AccessibilityMapCalculationParameter,
+    AccessibilityMapPolygonProperties
+} from 'evolution-backend/lib/services/routing/types';
 
-/**
- * Calculate the accessibility map for an address
- * @param address The address from which to get the accessibility map
- * @returns A multipolygon of the data, or null if the result could not be
- * calculated correctly
- */
-export const getAccessibilityMapFromAddress = async (
-    address: Address
-): Promise<AddressAccessibilityMapsDurations | null> => {
+const getAccessibilityMapFromAddress = async ({
+    address,
+    scenario,
+    extraParameters,
+    timeMappings = [15, 30, 45]
+}: {
+    address: Address;
+    scenario?: string;
+    extraParameters: Partial<AccessibilityMapCalculationParameter>;
+    // FIXME Because of speed limitations, the time mappings allow to request
+    // higher values for modes like driving and cycling, while mapping to 15, 30
+    // and 45 minutes equivalent. This value will not be needed when we actually
+    // support mode-specific isochrones in the API.
+    timeMappings?: number[];
+}): Promise<AddressAccessibilityMapsDurations | null> => {
     try {
         const addressGeography = address.geography;
         if (!addressGeography) {
             console.error('No geography found for address when getting accessibility map');
             return null;
         }
-        // Take a week scenario, as defined in the config
-        const scenario = config.trRoutingScenarios?.SE;
         if (scenario === undefined) {
             console.error('No transit scenario defined in config for accessibility map calculation');
             return null;
@@ -32,32 +40,92 @@ export const getAccessibilityMapFromAddress = async (
         // This will get 3 polygons for 15, 30 and 45 minutes that will be assigned to each property of the result
         const accessibilityMapResponse = await getTransitAccessibilityMap({
             point: addressGeography,
+            transitScenario: scenario,
             numberOfPolygons: 3,
-            maxTotalTravelTimeMinutes: 45,
+            calculatePois: true,
+            maxTotalTravelTimeMinutes: timeMappings[2],
             // FIXME Allow to parameterize these values
             departureSecondsSinceMidnight: 8 * 3600, // 8 AM
-            transitScenario: scenario,
-            calculatePois: true
+            ...extraParameters
         });
         if (accessibilityMapResponse.status !== 'success') {
-            console.log('Error getting summary: ', JSON.stringify(accessibilityMapResponse));
+            console.log('Error getting accessibility map: ', JSON.stringify(accessibilityMapResponse));
             return null;
         }
+
+        const findPolygonByDuration =
+            (durationMinutes: number) =>
+                (p: GeoJSON.Feature<GeoJSON.MultiPolygon, AccessibilityMapPolygonProperties>) =>
+                    p.properties.durationSeconds === durationMinutes;
         const polygonsByDuration = {
             duration15Minutes:
-                accessibilityMapResponse.polygons.features.find((p) => p.properties.durationSeconds === 15 * 60) ||
-                null,
+                accessibilityMapResponse.polygons.features.find(findPolygonByDuration(timeMappings[0] * 60)) || null,
             duration30Minutes:
-                accessibilityMapResponse.polygons.features.find((p) => p.properties.durationSeconds === 30 * 60) ||
-                null,
+                accessibilityMapResponse.polygons.features.find(findPolygonByDuration(timeMappings[1] * 60)) || null,
             duration45Minutes:
-                accessibilityMapResponse.polygons.features.find((p) => p.properties.durationSeconds === 45 * 60) || null
+                accessibilityMapResponse.polygons.features.find(findPolygonByDuration(timeMappings[2] * 60)) || null
         };
         return polygonsByDuration;
     } catch (error) {
         console.error('Error getting accessibility map from address', error);
         return null;
     }
+};
+
+/**
+ * Calculate the accessibility map for an address
+ * @param address The address from which to get the accessibility map
+ * @returns A multipolygon of the data, or null if the result could not be
+ * calculated correctly
+ */
+export const getAccessibilityMapFromAddressForTransit = async (
+    address: Address
+): Promise<AddressAccessibilityMapsDurations | null> => {
+    return getAccessibilityMapFromAddress({ address, scenario: config.trRoutingScenarios?.SE, extraParameters: {} });
+};
+
+const walkingSpeedKmPerHour = 5;
+// Speed of cycling is 15 km/h, so 3 times faster than walking
+const cyclingSpeedKmPerHour = 15;
+const cyclingTimingFactor = cyclingSpeedKmPerHour / walkingSpeedKmPerHour;
+// Speed of driving is 40 km/h, so 8 times faster than walking
+const drivingSpeedKmPerHour = 40;
+const drivingTimingFactor = drivingSpeedKmPerHour / walkingSpeedKmPerHour;
+/**
+ * Calculate the accessibility maps for simple modes (walking, cycling, driving)
+ * @param address The address form whcih to get the accessibility maps
+ * @returns An accessibility map by duration for walking, cycling and driving
+ */
+export const getAccessibilityMapFromAddressForSimpleModes = async (
+    address: Address
+): Promise<{
+    walking: AddressAccessibilityMapsDurations | null;
+    cycling: AddressAccessibilityMapsDurations | null;
+    driving: AddressAccessibilityMapsDurations | null;
+}> => {
+    // FIXME Hack: we use accessibility map for an empty transit scenario to
+    // get isochrones for simple modes. We just need to set the accessEgress
+    // time to the maximum duration, with a walking speed corresponding to
+    // the speed of the mode.
+    return {
+        walking: await getAccessibilityMapFromAddress({
+            address,
+            scenario: config.emptyScenarioForSimpleModes,
+            extraParameters: { maxAccessEgressTravelTimeMinutes: 45, walkingSpeedKmPerHour: walkingSpeedKmPerHour }
+        }),
+        cycling: await getAccessibilityMapFromAddress({
+            address,
+            scenario: config.emptyScenarioForSimpleModes,
+            extraParameters: { maxAccessEgressTravelTimeMinutes: 45 * cyclingTimingFactor },
+            timeMappings: [15 * cyclingTimingFactor, 30 * cyclingTimingFactor, 45 * cyclingTimingFactor]
+        }),
+        driving: await getAccessibilityMapFromAddress({
+            address,
+            scenario: config.emptyScenarioForSimpleModes,
+            extraParameters: { maxAccessEgressTravelTimeMinutes: 45 * drivingTimingFactor },
+            timeMappings: [15 * drivingTimingFactor, 30 * drivingTimingFactor, 45 * drivingTimingFactor]
+        })
+    };
 };
 
 const calculationModes = ['transit', 'walking', 'cycling', 'driving'] as RoutingOrTransitMode[];

--- a/localisation/src/survey/common/types.ts
+++ b/localisation/src/survey/common/types.ts
@@ -1,3 +1,5 @@
+import type { AccessibilityMapPolygonProperties } from 'evolution-backend/lib/services/routing/types';
+
 /**
  * Type for housing locations
  *
@@ -25,16 +27,21 @@ export type Address = {
     // Monthly utilities cost
     utilitiesMonthly?: number;
     monthlyCost?: CalculationResults;
-    accessibilityMap?: AddressAccessibilityMapsDurations | null;
+    accessibilityMapsByMode?: {
+        walking: AddressAccessibilityMapsDurations | null;
+        cycling: AddressAccessibilityMapsDurations | null;
+        driving: AddressAccessibilityMapsDurations | null;
+        transit: AddressAccessibilityMapsDurations | null;
+    } | null;
     routingTimeDistances?: {
         [destinationUuid: string]: RoutingByModeDistanceAndTime | null;
     } | null;
 };
 
 export type AddressAccessibilityMapsDurations = {
-    duration15Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
-    duration30Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
-    duration45Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon> | null;
+    duration15Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon, AccessibilityMapPolygonProperties> | null;
+    duration30Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon, AccessibilityMapPolygonProperties> | null;
+    duration45Minutes: GeoJSON.Feature<GeoJSON.MultiPolygon, AccessibilityMapPolygonProperties> | null;
 };
 
 export type TimeAndDistance = {

--- a/localisation/src/survey/sections/results/customWidgets.ts
+++ b/localisation/src/survey/sections/results/customWidgets.ts
@@ -67,11 +67,11 @@ export const comparisonMap: InfoMapWidgetConfig = {
             addressGeography.properties!.sequence = address._sequence;
             pointGeographies.push(addressGeography);
 
-            if (address.accessibilityMap?.duration30Minutes) {
+            if (address.accessibilityMapsByMode?.transit?.duration30Minutes) {
                 const accessibilityMapPolygon = {
-                    ...address.accessibilityMap.duration30Minutes,
+                    ...address.accessibilityMapsByMode.transit.duration30Minutes,
                     properties: {
-                        ...(address.accessibilityMap.duration30Minutes.properties || {}),
+                        ...(address.accessibilityMapsByMode.transit.duration30Minutes.properties || {}),
                         strokeColor: colorPalette[addressIndex % colorPalette.length],
                         fillColor: colorPalette[addressIndex % colorPalette.length]
                     }

--- a/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
+++ b/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
@@ -44,10 +44,16 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                     ]
                 ]
             },
-            properties: {}
+            properties: { durationSeconds: 30 * 60, areaSqM: 4000000 }
         },
         duration45Minutes: null
     };
+    const mockAccessibilityMapsByModeResult = {
+        transit: mockAccessibilityMap,
+        walking: mockAccessibilityMap,
+        cycling: mockAccessibilityMap,
+        driving: mockAccessibilityMap
+    }
     const mockRoutingTimeDistances = {
         'destination-uuid-1': {
             _uuid: 'destination-uuid-1',
@@ -115,7 +121,7 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
         jest.clearAllMocks();
         // Set up default mock return values
         mockCalculateAccessibilityAndRouting.mockResolvedValue({
-            accessibilityMap: mockAccessibilityMap,
+            accessibilityMapsByMode: mockAccessibilityMapsByModeResult,
             routingTimeDistances: mockRoutingTimeDistances
         });
     });
@@ -168,8 +174,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 carCostMonthly: 350,
                 totalCostMonthly: 1550
             });
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect(result['addresses.address-1.accessibilityMap']).toEqual(mockAccessibilityMap);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual(mockAccessibilityMapsByModeResult);
             expect(mockCalculateMonthlyCost).toHaveBeenCalledWith(address, interview);
             expect(mockCalculateAccessibilityAndRouting).toHaveBeenCalledWith(address, interview);
         });
@@ -203,8 +209,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBeLessThan(2300);
             expect(result['addresses.address-1.monthlyCost'].housingCostPercentageOfIncome).toBeNull();
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(450);
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect(result['addresses.address-1.accessibilityMap']).toEqual(mockAccessibilityMap);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual(mockAccessibilityMapsByModeResult);
             expect(result['addresses.address-1.routingTimeDistances']).toEqual(mockRoutingTimeDistances);
         });
 
@@ -250,15 +256,15 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
 
             expect('addresses.address-1.monthlyCost' in result).toBe(true);
             expect('addresses.address-2.monthlyCost' in result).toBe(true);
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect('addresses.address-2.accessibilityMap' in result).toBe(true);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect('addresses.address-2.accessibilityMapsByMode' in result).toBe(true);
 
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBe(1200);
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(300);
             expect(result['addresses.address-2.monthlyCost'].housingCostMonthly).toBe(1650);
             expect(result['addresses.address-2.monthlyCost'].carCostMonthly).toBe(400);
-            expect(result['addresses.address-1.accessibilityMap']).toEqual(mockAccessibilityMap);
-            expect(result['addresses.address-2.accessibilityMap']).toEqual(mockAccessibilityMap);
+            expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual(mockAccessibilityMapsByModeResult);
+            expect(result['addresses.address-2.accessibilityMapsByMode']).toEqual(mockAccessibilityMapsByModeResult);
             expect(result['addresses.address-1.routingTimeDistances']).toEqual(mockRoutingTimeDistances);
             expect(result['addresses.address-2.routingTimeDistances']).toEqual(mockRoutingTimeDistances);
             
@@ -297,7 +303,7 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 });
 
             mockCalculateAccessibilityAndRouting.mockResolvedValue({
-                accessibilityMap: null,
+                accessibilityMapsByMode: null,
                 routingTimeDistances: null
             });
 
@@ -313,8 +319,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(310);
             expect(result['addresses.address-2.monthlyCost'].housingCostMonthly).toBeNull();
             expect(result['addresses.address-2.monthlyCost'].carCostMonthly).toBeNull();
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect('addresses.address-2.accessibilityMap' in result).toBe(true);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect('addresses.address-2.accessibilityMapsByMode' in result).toBe(true);
             expect('addresses.address-1.routingTimeDistances' in result).toBe(true);
             expect('addresses.address-2.routingTimeDistances' in result).toBe(true);
         });
@@ -405,7 +411,7 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             expect('addresses.address-1.monthlyCost' in result).toBe(true);
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBe(1200);
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(250);
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
         });
 
         it('should not calculate if last element is not results section', async () => {
@@ -546,8 +552,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             expect(result['addresses.address-2.monthlyCost'].housingCostMonthly).toBe(1100);
             expect(result['addresses.address-2.monthlyCost'].carCostMonthly).toBe(270);
             expect(result['addresses.address-2.monthlyCost'].totalCostMonthly).toBe(1370);
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect('addresses.address-2.accessibilityMap' in result).toBe(true);
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect('addresses.address-2.accessibilityMapsByMode' in result).toBe(true);
             expect('addresses.address-1.routingTimeDistances' in result).toBe(true);
             expect('addresses.address-2.routingTimeDistances' in result).toBe(true);
         });
@@ -571,7 +577,7 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             });
 
             mockCalculateAccessibilityAndRouting.mockResolvedValue({
-                accessibilityMap: null,
+                accessibilityMapsByMode: null,
                 routingTimeDistances: null
             });
 
@@ -580,8 +586,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
 
             const result = await sectionsActionsCallback.callback(interview, value) as any;
 
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect(result['addresses.address-1.accessibilityMap']).toBeNull();
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect(result['addresses.address-1.accessibilityMapsByMode']).toBeNull();
             expect('addresses.address-1.routingTimeDistances' in result).toBe(true);
             expect(result['addresses.address-1.routingTimeDistances']).toBeNull();
         });
@@ -610,8 +616,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             const result = await sectionsActionsCallback.callback(interview, value) as any;
 
             // Should return a partial object with null accessibility map but monthly cost results
-            expect('addresses.address-1.accessibilityMap' in result).toBe(true);
-            expect(result['addresses.address-1.accessibilityMap']).toBeNull();
+            expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
+            expect(result['addresses.address-1.accessibilityMapsByMode']).toBeNull();
             expect('addresses.address-1.routingTimeDistances' in result).toBe(true);
             expect(result['addresses.address-1.routingTimeDistances']).toBeNull();
             expect('addresses.address-1.monthlyCost' in result).toBe(true);

--- a/localisation/src/survey/server/serverFieldUpdate.ts
+++ b/localisation/src/survey/server/serverFieldUpdate.ts
@@ -25,8 +25,8 @@ export default [
                     calculationPromises.push(
                         calculateAccessibilityAndRouting(address, interview)
                             .then((accessibilityAndRouting) => {
-                                updatedValues[`addresses.${address._uuid}.accessibilityMap`] =
-                                    accessibilityAndRouting.accessibilityMap;
+                                updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] =
+                                    accessibilityAndRouting.accessibilityMapsByMode;
                                 updatedValues[`addresses.${address._uuid}.routingTimeDistances`] =
                                     accessibilityAndRouting.routingTimeDistances;
                             })
@@ -36,7 +36,7 @@ export default [
                                     address._uuid,
                                     error
                                 );
-                                updatedValues[`addresses.${address._uuid}.accessibilityMap`] = null;
+                                updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = null;
                                 updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = null;
                             })
                     );


### PR DESCRIPTION
part of #20

Add a config to provide an empty scenario, that will always return a walking accessibility map around the address (ie for now, a circle) of durations 15, 30 and 45 minutes.

Update the types of the accessibilityMaps so it is now by mode. The `Address`'s `accessibilityMap` field now becomes
`accessibilityMapsByMode` and is an object where the keys are the modes (similar to the RoutingResultByMode) and the values are the Feature for each duration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accessibility maps are now calculated and returned separately for each transport mode (transit, walking, cycling, driving), providing more granular travel-time insights.

* **Improvements**
  * Calculation scenarios and time mappings have been enhanced to handle transit and non-transit modes differently.
  * Accessibility polygon results now include additional metadata (e.g., area) for clearer spatial insight.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->