### PR TITLE
calculations: run routing and accessibility asynchronously

### DIFF
--- a/localisation/package.json
+++ b/localisation/package.json
@@ -53,7 +53,8 @@
     "react-dom": "^19.2.3",
     "react-i18next": "^16.5.3",
     "react-router": "^7.12.0",
-    "recharts": "^3.2.1"
+    "recharts": "^3.2.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@alienfast/i18next-loader": "^2.0.2",

--- a/localisation/src/survey/common/types.ts
+++ b/localisation/src/survey/common/types.ts
@@ -27,15 +27,21 @@ export type Address = {
     // Monthly utilities cost
     utilitiesMonthly?: number;
     monthlyCost?: CalculationResults;
-    accessibilityMapsByMode?: {
-        walking: AddressAccessibilityMapsDurations | null;
-        cycling: AddressAccessibilityMapsDurations | null;
-        driving: AddressAccessibilityMapsDurations | null;
-        transit: AddressAccessibilityMapsDurations | null;
-    } | null;
-    routingTimeDistances?: {
-        [destinationUuid: string]: RoutingByModeDistanceAndTime | null;
-    } | null;
+    accessibilityMapsByMode?:
+        | {
+              walking: AddressAccessibilityMapsDurations | null;
+              cycling: AddressAccessibilityMapsDurations | null;
+              driving: AddressAccessibilityMapsDurations | null;
+              transit: AddressAccessibilityMapsDurations | null;
+          }
+        | null
+        | 'calculating';
+    routingTimeDistances?:
+        | {
+              [destinationUuid: string]: RoutingByModeDistanceAndTime | null;
+          }
+        | null
+        | 'calculating';
 };
 
 export type AddressAccessibilityMapsDurations = {

--- a/localisation/src/survey/sections/results/customWidgets.ts
+++ b/localisation/src/survey/sections/results/customWidgets.ts
@@ -98,6 +98,11 @@ export const comparisonMap: InfoMapWidgetConfig = {
             addressGeography.properties!.sequence = address._sequence;
             pointGeographies.push(addressGeography);
 
+            // Skip if the accessibility map is still being calculated
+            if (address.accessibilityMapsByMode === 'calculating') {
+                continue;
+            }
+
             // Transform the selected travel time to the property name of the accessibility map
             const durationProperty = `duration${selectedTravelTime}Minutes` as
                 | 'duration15Minutes'

--- a/localisation/src/survey/server/serverFieldUpdate.ts
+++ b/localisation/src/survey/server/serverFieldUpdate.ts
@@ -1,47 +1,78 @@
 import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
 import { getAddressesArray } from '../common/customHelpers';
 import { calculateAccessibilityAndRouting, calculateMonthlyCost } from '../calculations';
+import { Address } from '../common/types';
 
 // FIXME Add callbacks to invalidate results when geographies change and calculate results only on demand
 export default [
     {
         field: '_sections._actions',
         runOnValidatedData: false, // make sure not to run in validation mode!
-        callback: async (interview: InterviewAttributes, value) => {
+        callback: async (interview: InterviewAttributes, value, _path, registerUpdateOperation?) => {
             // Calculate monthly cost of localisation and trip data
             try {
                 // Return if the change is not happening in the results section
                 if (!(Array.isArray(value) && value[value.length - 1]?.section === 'results')) {
                     return {};
                 }
+
+                // FIXME This should not be calculated upon section entry.
+                // Ideally, all calculations should be done as soon as the
+                // information is available.
+                const executeAccessibilityAndRoutingCalculations = async (address: Address) => {
+                    const updatedValues = {};
+                    try {
+                        const accessibilityAndRouting = await calculateAccessibilityAndRouting(address, interview);
+                        updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] =
+                            accessibilityAndRouting.accessibilityMapsByMode;
+                        updatedValues[`addresses.${address._uuid}.routingTimeDistances`] =
+                            accessibilityAndRouting.routingTimeDistances;
+                    } catch (error) {
+                        console.error('error calculating accessibility and routing for address', address._uuid, error);
+                        updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = null;
+                        updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = null;
+                    }
+
+                    return updatedValues;
+                };
+
                 const updatedValues = {};
                 // Calculate the monthly cost for each address
                 const addresses = getAddressesArray(interview);
-                const calculationPromises: Promise<void>[] = [];
                 for (let i = 0; i < addresses.length; i++) {
                     const address = addresses[i];
                     const calculationResults = calculateMonthlyCost(address, interview);
                     updatedValues[`addresses.${address._uuid}.monthlyCost`] = calculationResults;
-                    calculationPromises.push(
-                        calculateAccessibilityAndRouting(address, interview)
-                            .then((accessibilityAndRouting) => {
-                                updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] =
-                                    accessibilityAndRouting.accessibilityMapsByMode;
-                                updatedValues[`addresses.${address._uuid}.routingTimeDistances`] =
-                                    accessibilityAndRouting.routingTimeDistances;
-                            })
-                            .catch((error) => {
-                                console.error(
-                                    'error calculating accessibility and routing for address',
-                                    address._uuid,
-                                    error
-                                );
-                                updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = null;
-                                updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = null;
-                            })
-                    );
+                    if (registerUpdateOperation) {
+                        if (address.geography && address.geography.geometry?.type === 'Point') {
+                            // Execute the operation in the backend so the result may be ready when needed, but without blocking the call
+                            registerUpdateOperation({
+                                opName: `addressCalculations${address._uuid}`,
+                                opUniqueId: 1,
+                                operation: async (_isCancelled: () => boolean) => {
+                                    // FIXME Use the _isCancelled callback to stop the calculation
+                                    return executeAccessibilityAndRoutingCalculations(address);
+                                }
+                            });
+                            updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = 'calculating';
+                            updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = 'calculating';
+                        } else {
+                            console.warn(
+                                'Address does not have valid geography, skipping accessibility and routing calculations for address',
+                                address._uuid
+                            );
+                            updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = null;
+                            updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = null;
+                        }
+                    } else {
+                        // FIXME Implement this for the admin case, not currently used
+                        console.warn(
+                            'No registerUpdateOperation function provided to serverFieldUpdate callback, results will not be registered as part of the current update operation. This should happen only in admin mode'
+                        );
+                        updatedValues[`addresses.${address._uuid}.accessibilityMapsByMode`] = null;
+                        updatedValues[`addresses.${address._uuid}.routingTimeDistances`] = null;
+                    }
                 }
-                await Promise.all(calculationPromises);
                 return updatedValues;
             } catch (error) {
                 console.error('error calculating monthly cost', error);


### PR DESCRIPTION
fixes #21

This runs the calculations for each address asynchronously on the server. During calculation, it sets the value to `calculating`, telling the UI to trigger a call to the server to retrieve the results after a certain delay.

The delay is 3 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transient "calculating" placeholders for accessibility maps and routing time results.
  * Loading states and periodic refreshes added to results and accessibility panels.
  * Backend can register background update operations so long-running calculations complete asynchronously.

* **Bug Fixes**
  * Skip processing/rendering of addresses while their calculations are pending.

* **Tests**
  * Tests added/updated to cover admin vs non-admin registration and placeholder behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->