### PR TITLE
Add the "import dissemination blocks" task to Localisation

### DIFF
--- a/localisation/.eslintrc.json
+++ b/localisation/.eslintrc.json
@@ -1,6 +1,7 @@
 {
     "extends": "../evolution/configs/base.eslintrc.json",
     "rules": {
-        "@typescript-eslint/no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "argsIgnorePattern": "^_", "ignoreRestSiblings": false }]
+        "@typescript-eslint/no-unused-vars": ["warn", { "vars": "all", "args": "after-used", "argsIgnorePattern": "^_", "ignoreRestSiblings": false }],
+        "n/no-process-exit": "off" // Tasks need to use process.exit(), throw, as suggested, keeps the process running
     }
 }

--- a/localisation/package.json
+++ b/localisation/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@fortawesome/free-solid-svg-icons": "^7.1.0",
     "@fortawesome/react-fontawesome": "^3.1.1",
+    "@inquirer/prompts": "^8.2.0",
     "@turf/turf": "^7.3.1",
     "chaire-lib-backend": "^0.2.2",
     "chaire-lib-common": "^0.2.2",
@@ -44,6 +45,7 @@
     "evolution-common": "^0.6.0",
     "evolution-frontend": "^0.6.0",
     "i18next": "^25.7.4",
+    "inquirer-file-selector": "^1.0.1",
     "moment": "^2.30.1",
     "moment-business-days": "^1.2.0",
     "moment-timezone": "^0.5.48",
@@ -54,7 +56,8 @@
     "react-i18next": "^16.5.3",
     "react-router": "^7.12.0",
     "recharts": "^3.2.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "xml-reader": "^2.4.3"
   },
   "devDependencies": {
     "@alienfast/i18next-loader": "^2.0.2",

--- a/localisation/src/importers/ProximityMeasuresImporter.ts
+++ b/localisation/src/importers/ProximityMeasuresImporter.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import zonesQueries from 'chaire-lib-backend/lib/models/db/zones.db.queries';
+import { parseCsvFile } from 'chaire-lib-backend/lib/services/files/CsvFile';
+import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
+
+// COPY-PASTE WARNING: Code mostly copied from transition and added here so we can import the proximity indices to Localisation's database.
+// We currently have no need for the population data, so we have removed the population import for now.
+
+// A structure to hold Statcan's proximity data. See https://www150.statcan.gc.ca/n1/pub/17-26-0002/172600022023001-eng.htm for more info.
+interface ProximityIndices {
+    /** Normalised value of a dissemination block's proximity to employment. */
+    prox_idx_emp: number | null;
+    /** Normalised value of a dissemination block's proximity to pharmacy and drug stores. */
+    prox_idx_pharma: number | null;
+    /** Normalised value of a dissemination block's proximity to child care facilities. */
+    prox_idx_childcare: number | null;
+    /** Normalised value of a dissemination block's proximity to health facilities. */
+    prox_idx_health: number | null;
+    /** Normalised value of a dissemination block's proximity to grocery stores. */
+    prox_idx_grocery: number | null;
+    /** Normalised value of a dissemination block's proximity to primary education facilities. */
+    prox_idx_educpri: number | null;
+    /** Normalised value of a dissemination block's proximity to secondary education facilities. */
+    prox_idx_educsec: number | null;
+    /** Normalised value of a dissemination block's proximity to libraries. */
+    prox_idx_lib: number | null;
+    /** Normalised value of a dissemination block's proximity to parks. */
+    prox_idx_parks: number | null;
+    /** Normalised value of a dissemination block's proximity to transit trips. */
+    prox_idx_transit: number | null;
+}
+
+export default async function importProximityMeasuresFromCsv(proximityFile: string): Promise<void> {
+    if (!fileManager.fileExistsAbsolute(proximityFile)) {
+        throw new Error(`Proximity CSV file not found: ${proximityFile}`);
+    }
+
+    let lineCounter = 0;
+
+    console.log('Parsing through CSV FILE:');
+
+    const csvData: { id: string[]; indices: ProximityIndices[] }[] = [];
+
+    let indexChunk: ProximityIndices[] = [];
+    let idChunk: string[] = [];
+
+    const batchSize = 10000;
+
+    await parseCsvFile(
+        proximityFile,
+        (line, rowNumber) => {
+            lineCounter++;
+
+            idChunk.push(line.DBUID);
+
+            const indexRow = {
+                // The CSV file uses two periods to represent null indices.
+                prox_idx_emp: line.prox_idx_emp === '..' ? null : Number(line.prox_idx_emp),
+                prox_idx_pharma: line.prox_idx_pharma === '..' ? null : Number(line.prox_idx_pharma),
+                prox_idx_childcare: line.prox_idx_childcare === '..' ? null : Number(line.prox_idx_childcare),
+                prox_idx_health: line.prox_idx_health === '..' ? null : Number(line.prox_idx_health),
+                prox_idx_grocery: line.prox_idx_grocery === '..' ? null : Number(line.prox_idx_grocery),
+                prox_idx_educpri: line.prox_idx_educpri === '..' ? null : Number(line.prox_idx_educpri),
+                prox_idx_educsec: line.prox_idx_educsec === '..' ? null : Number(line.prox_idx_educsec),
+                prox_idx_lib: line.prox_idx_lib === '..' ? null : Number(line.prox_idx_lib),
+                prox_idx_parks: line.prox_idx_parks === '..' ? null : Number(line.prox_idx_parks),
+                prox_idx_transit: line.prox_idx_transit === '..' ? null : Number(line.prox_idx_transit)
+            };
+
+            indexChunk.push(indexRow);
+            if (lineCounter % 100 === 0) {
+                console.log(`CSV rows parsed: ${rowNumber}`);
+            }
+
+            if (idChunk.length >= batchSize) {
+                csvData.push({ id: idChunk, indices: indexChunk });
+                idChunk = [];
+                indexChunk = [];
+            }
+        },
+        { header: true }
+    );
+
+    if (idChunk.length > 0) {
+        csvData.push({ id: idChunk, indices: indexChunk });
+    }
+
+    console.log(`There are ${lineCounter} dissemination blocks.`);
+    console.log('Adding proximity indices data to database:');
+    let dbCounter = 0;
+    for (const batch of csvData) {
+        console.log(`CSV data added to DB: ${dbCounter * batchSize}/${lineCounter}`);
+
+        const jsonBatch = batch.id.map((id, index) => {
+            return { internalId: id, json: batch.indices[index] };
+        });
+        await zonesQueries.addJsonDataBatch(jsonBatch);
+
+        dbCounter++;
+    }
+    console.log('Added proximity indices data!');
+}

--- a/localisation/src/importers/ZonesImporter.ts
+++ b/localisation/src/importers/ZonesImporter.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import { v4 as uuidV4 } from 'uuid';
+import xmlReader from 'xml-reader';
+import fs from 'fs';
+
+import zonesQueries from 'chaire-lib-backend/lib/models/db/zones.db.queries';
+import { fileManager } from 'chaire-lib-backend/lib/utils/filesystem/fileManager';
+import { ZoneAttributes } from 'chaire-lib-common/lib/services/zones/Zone';
+
+// COPY-PASTE WARNING: Code mostly copied from transition and added here so we can import the proximity indices to Localisation's database.
+
+// The structure of the object given by the xml-reader package. Copied from the npm page.
+interface XmlNode {
+    /** element name (empty for text nodes) */
+    name: string;
+    /** node type (element or text), see NodeType constants */
+    type: string;
+    /** value of a text node */
+    value: string;
+    /** reference to parent node (null with parentNodes option disabled or root node) */
+    parent: XmlNode;
+    /** map of attributes name => value */
+    attributes: { [name: string]: string };
+    /** array of children nodes */
+    children: XmlNode[];
+}
+
+// Import zone boundaries in the tr_zone tables using gml files from Statistics Canada.
+export default async function importBoundariesFromGml(boundariesFile: string, dataSourceId: string): Promise<void> {
+    if (!fileManager.fileExistsAbsolute(boundariesFile)) {
+        throw new Error(`Boundaries GML file not found: ${boundariesFile}`);
+    }
+
+    const parser = xmlReader.create({ stream: true, parentNodes: false });
+    const readStream = fs.createReadStream(boundariesFile);
+    let i = 0;
+
+    const batchSize = 500;
+    let batch: {
+        zone: Omit<ZoneAttributes, 'geography'>;
+        spatialReferenceId: string;
+        geography: string;
+    }[] = [];
+
+    console.log('Parsing through GML FILE:');
+
+    parser.on('tag:gml:featureMember', (feature: XmlNode) => {
+        try {
+            const fme = feature.children[0];
+
+            // The id of the zone.
+            const dbuid = (fme.children.find((element) => element.name === 'fme:DBUID') as XmlNode).children[0].value;
+
+            const multiCoorList: string[] = [];
+
+            // The spatial reference id of the coordinate system used. Necessary to later convert into the coordinates used by Transition.
+            let spatialReferenceId: string = '';
+
+            // The GML file uses two types of geometry for the zones: simple surfaces and multi surfaces, with slightly different structures that need their own parsing logic
+            // Most of them are simple surfaces, with multi surfaces having multiple non connected polygons, such as zones that includes islands
+            const surfaceProperty = fme.children.find((element) => element.name === 'gml:surfaceProperty');
+            if (surfaceProperty !== undefined) {
+                const surface = surfaceProperty.children[0];
+                const srsName = surface.attributes.srsName;
+                spatialReferenceId = srsName.split('EPSG:')[1];
+                const polygonPatch = surface.children[0].children[0];
+                // Multiple children means a zone has one or more hole in the middle, containing a smaller zone.
+                for (const singlePolygon of polygonPatch.children) {
+                    const ring = singlePolygon.children[0];
+                    const ringType = ring.name;
+                    // A few zones are incorrectly written in the file, with nonsense geometry like single dots. The right zones are all linear rings.
+                    if (ringType === 'gml:LinearRing') {
+                        const posList = ring.children[0].children[0].value;
+                        multiCoorList.push(`((${addCommasToPosList(posList)}))`);
+                    }
+                }
+            }
+
+            const multiSurfaceProperty = fme.children.find((element) => element.name === 'gml:multiSurfaceProperty');
+            if (multiSurfaceProperty !== undefined) {
+                const multiSurface = multiSurfaceProperty.children[0];
+                const srsName = multiSurface.attributes.srsName;
+                spatialReferenceId = srsName.split('EPSG:')[1];
+                const surfaceMembers = multiSurface.children;
+                for (const surfaceMember of surfaceMembers) {
+                    const polygonPatch = surfaceMember.children[0].children[0].children[0];
+                    for (const singlePolygon of polygonPatch.children) {
+                        const ring = singlePolygon.children[0];
+                        const ringType = ring.name;
+                        if (ringType === 'gml:LinearRing') {
+                            const posList = ring.children[0].children[0].value;
+                            multiCoorList.push(`((${addCommasToPosList(posList)}))`);
+                        }
+                    }
+                }
+            }
+
+            if (multiCoorList.length >= 1) {
+                const zoneData = {
+                    id: uuidV4(),
+                    internal_id: dbuid,
+                    dataSourceId,
+                    data: {}
+                };
+                batch.push({
+                    zone: zoneData,
+                    spatialReferenceId,
+                    geography: `MULTIPOLYGON(${multiCoorList.join()})`
+                });
+            }
+
+            if (batch.length >= batchSize) {
+                readStream.pause();
+                zonesQueries.addZonesAndConvertedGeography(batch);
+                readStream.resume();
+                batch = [];
+            }
+
+            i++;
+            if (i % 100 === 0) {
+                console.log(`Zones parsed and added to DB: ${i}`);
+            }
+        } catch (error) {
+            console.log(`Error while reading the gml file: ${error}`);
+            readStream.destroy();
+        }
+    });
+
+    parser.on('done', async () => {
+        if (batch.length > 0) {
+            readStream.pause();
+            await zonesQueries.addZonesAndConvertedGeography(batch);
+            readStream.resume();
+        }
+        console.log(`Finished! There are ${i} new zones.`);
+    });
+
+    return new Promise((resolve, reject) => {
+        readStream.on('data', (chunk) => {
+            parser.parse(chunk.toString());
+        });
+
+        readStream.on('error', (err) => {
+            console.log(`Error while reading the stream: ${err}`);
+            reject();
+        });
+
+        readStream.on('close', () => {
+            resolve();
+        });
+    });
+}
+
+export function addCommasToPosList(posList: string): string {
+    const individualCoordinates = posList.split(' ');
+    const result: string[] = [];
+
+    for (let i = 0; i < individualCoordinates.length; i++) {
+        let coor = individualCoordinates[i];
+
+        // We want to add a comma after every second number to separate the coordinates (but not the last one)
+        if (i < individualCoordinates.length - 1) {
+            coor += i % 2 === 0 ? ' ' : ',';
+        }
+
+        result.push(coor);
+    }
+
+    return result.join('');
+}

--- a/localisation/src/scripts/importDisseminationBlocksCanada.task.ts
+++ b/localisation/src/scripts/importDisseminationBlocksCanada.task.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+// COPY-PASTE WARNING: This task is mostly copied from transition and added here so we can import the proximity indices to Localisation's database.
+// We currently have no need for the population data, so we have removed the population import for now.
+import { ImportDisseminationBlocksCanada } from '../tasks/importDisseminationBlocksCanada';
+import taskWrapper from 'chaire-lib-backend/lib/tasks/taskWrapper';
+
+taskWrapper(new ImportDisseminationBlocksCanada())
+    .then(() => {
+        process.exit();
+    })
+    .catch((err) => {
+        console.error('Error executing task', err);
+        process.exit();
+    });

--- a/localisation/src/tasks/importDisseminationBlocksCanada.ts
+++ b/localisation/src/tasks/importDisseminationBlocksCanada.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+
+import { select } from '@inquirer/prompts';
+import { fileSelector } from 'inquirer-file-selector';
+
+import importBoundariesFromGml from '../importers/ZonesImporter';
+import importProximityMeasuresFromCsv from '../importers/ProximityMeasuresImporter';
+import { GenericTask } from 'chaire-lib-backend/lib/tasks/genericTask';
+import dsQueries from 'chaire-lib-backend/lib/models/db/dataSources.db.queries';
+import zonesQueries from 'chaire-lib-backend/lib/models/db/zones.db.queries';
+import DataSource from 'chaire-lib-common/lib/services/dataSource/DataSource';
+
+// COPY-PASTE WARNING: Code mostly copied from transition and added here so we can import the proximity indices to Localisation's database.
+// We currently have no need for the population data, so we have removed the population import for now.
+export class ImportDisseminationBlocksCanada implements GenericTask {
+    private async promptOverwriteDataSource(dataSourceName: string): Promise<boolean> {
+        const overwrite = await select({
+            message: `${dataSourceName} already exists. Do you want to re-create the places in this data source?`,
+            choices: [
+                { name: 'Yes', value: true },
+                { name: 'No', value: false }
+            ]
+        });
+        return overwrite;
+    }
+
+    // This function is meant to work with the GML file found here: https://www12.statcan.gc.ca/census-recensement/2021/geo/sip-pis/boundary-limites/index2021-eng.cfm?year=21
+    // TODO: We want to support other file types eventually, like geojson.
+    private async importBoundaries(boundariesFile: string | undefined, dataSourceId: string): Promise<void> {
+        let file = boundariesFile;
+        if (file === undefined) {
+            // Request the file from the user
+            const selection = await fileSelector({
+                message: 'Please select the dissemination blocks boundaries file to import',
+                filter: (item) => item.isDirectory || item.name.endsWith('.gml')
+            });
+            file = selection.path;
+        }
+
+        if (typeof file !== 'string') {
+            throw new Error('File is undefined');
+        }
+
+        await importBoundariesFromGml(file, dataSourceId);
+    }
+
+    // This function is meant to work with the CSV file found here: https://www150.statcan.gc.ca/n1/pub/17-26-0002/172600022023001-eng.htm
+    private async importIndexes(proximityFile: string | undefined): Promise<void> {
+        let file = proximityFile;
+        if (file === undefined) {
+            // Request the file from the user
+            const selection = await fileSelector({
+                message: 'Please select the proximity index file to import',
+                filter: (item) => item.isDirectory || item.name.endsWith('.csv')
+            });
+            file = selection.path;
+        }
+
+        if (typeof file !== 'string') {
+            throw new Error('File is undefined');
+        }
+
+        await importProximityMeasuresFromCsv(file);
+    }
+
+    public async run(argv: { [key: string]: unknown }): Promise<void> {
+        // Handle arguments and default values
+        const boundariesFile = argv['boundaries-file'] !== undefined ? (argv['boundaries-file'] as string) : undefined;
+        const proximityFile = argv['proximity-file'] !== undefined ? (argv['proximity-file'] as string) : undefined;
+
+        const dataSourceName = 'Dissemination block boundaries 2021';
+
+        const currentDataSourceAttributes = await dsQueries.findByName(dataSourceName);
+        const currentDataSource =
+            currentDataSourceAttributes === undefined
+                ? new DataSource({ name: dataSourceName, shortname: dataSourceName, type: 'zones' }, true)
+                : new DataSource(currentDataSourceAttributes, false);
+
+        if (currentDataSourceAttributes === undefined || (await this.promptOverwriteDataSource(dataSourceName))) {
+            const dataSourceId = currentDataSource.getId();
+
+            // Create data source in the database or reset its data
+            if (currentDataSourceAttributes === undefined) {
+                console.log('Creating data source...');
+                await dsQueries.create(currentDataSource.attributes);
+                console.log('Data source created.');
+            } else {
+                console.log('Resetting data source...');
+                await zonesQueries.deleteForDataSourceId(dataSourceId);
+                console.log('Data source reset.');
+            }
+
+            await this.importBoundaries(boundariesFile, dataSourceId);
+            await this.importIndexes(proximityFile);
+        } else {
+            console.log(`Not re-creating places in existing data source '${dataSourceName}'.`);
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1255,6 +1255,11 @@
   resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-1.0.2.tgz#674a4c4d81ad460695cb2a1fc69d78cd187f337e"
   integrity sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==
 
+"@inquirer/ansi@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/ansi/-/ansi-2.0.3.tgz#3c4c5b587894278996c2750db83d89fb547b796b"
+  integrity sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==
+
 "@inquirer/checkbox@^4.3.2":
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-4.3.2.tgz#e1483e6519d6ffef97281a54d2a5baa0d81b3f3b"
@@ -1266,6 +1271,16 @@
     "@inquirer/type" "^3.0.10"
     yoctocolors-cjs "^2.1.3"
 
+"@inquirer/checkbox@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/checkbox/-/checkbox-5.0.4.tgz#813e8fd64c5f9ce064e4a6517a1fcc4524d2cf05"
+  integrity sha512-DrAMU3YBGMUAp6ArwTIp/25CNDtDbxk7UjIrrtM25JVVrlVYlVzHh5HR1BDFu9JMyUoZ4ZanzeaHqNDttf3gVg==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
 "@inquirer/confirm@^5.1.21":
   version "5.1.21"
   resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-5.1.21.tgz#610c4acd7797d94890a6e2dde2c98eb1e891dd12"
@@ -1273,6 +1288,14 @@
   dependencies:
     "@inquirer/core" "^10.3.2"
     "@inquirer/type" "^3.0.10"
+
+"@inquirer/confirm@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/confirm/-/confirm-6.0.4.tgz#548d63981f3bc189ee0773015fbe4625e7a204a0"
+  integrity sha512-WdaPe7foUnoGYvXzH4jp4wH/3l+dBhZ3uwhKjXjwdrq5tEIFaANxj6zrGHxLdsIA0yKM0kFPVcEalOZXBB5ISA==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/core@^10.1.14", "@inquirer/core@^10.3.2":
   version "10.3.2"
@@ -1288,6 +1311,19 @@
     wrap-ansi "^6.2.0"
     yoctocolors-cjs "^2.1.3"
 
+"@inquirer/core@^11.1.1":
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/@inquirer/core/-/core-11.1.1.tgz#7cf708b350f9e73b01ccb4b61ecf3016d3de1b0d"
+  integrity sha512-hV9o15UxX46OyQAtaoMqAOxGR8RVl1aZtDx1jHbCtSJy1tBdTfKxLPKf7utsE4cRy4tcmCQ4+vdV+ca+oNxqNA==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+    cli-width "^4.1.0"
+    mute-stream "^3.0.0"
+    signal-exit "^4.1.0"
+    wrap-ansi "^9.0.2"
+
 "@inquirer/editor@^4.2.23":
   version "4.2.23"
   resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-4.2.23.tgz#fe046a3bfdae931262de98c1052437d794322e0b"
@@ -1296,6 +1332,15 @@
     "@inquirer/core" "^10.3.2"
     "@inquirer/external-editor" "^1.0.3"
     "@inquirer/type" "^3.0.10"
+
+"@inquirer/editor@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/editor/-/editor-5.0.4.tgz#8dda8bc92ca5a7f7326b4508f8da90358fbedfc5"
+  integrity sha512-QI3Jfqcv6UO2/VJaEFONH8Im1ll++Xn/AJTBn9Xf+qx2M+H8KZAdQ5sAe2vtYlo+mLW+d7JaMJB4qWtK4BG3pw==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/external-editor" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/expand@^4.0.23":
   version "4.0.23"
@@ -1306,6 +1351,14 @@
     "@inquirer/type" "^3.0.10"
     yoctocolors-cjs "^2.1.3"
 
+"@inquirer/expand@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/expand/-/expand-5.0.4.tgz#72adbd795c451deb6e74d04d5da91e41a45372d3"
+  integrity sha512-0I/16YwPPP0Co7a5MsomlZLpch48NzYfToyqYAOWtBmaXSB80RiNQ1J+0xx2eG+Wfxt0nHtpEWSRr6CzNVnOGg==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
 "@inquirer/external-editor@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-1.0.3.tgz#c23988291ee676290fdab3fd306e64010a6d13b8"
@@ -1314,10 +1367,23 @@
     chardet "^2.1.1"
     iconv-lite "^0.7.0"
 
+"@inquirer/external-editor@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/external-editor/-/external-editor-2.0.3.tgz#c9e84d8d6040968bee33232683b05642001a4731"
+  integrity sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==
+  dependencies:
+    chardet "^2.1.1"
+    iconv-lite "^0.7.2"
+
 "@inquirer/figures@^1.0.12", "@inquirer/figures@^1.0.15":
   version "1.0.15"
   resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-1.0.15.tgz#dbb49ed80df11df74268023b496ac5d9acd22b3a"
   integrity sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==
+
+"@inquirer/figures@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/figures/-/figures-2.0.3.tgz#9d0cd242fbdb4ed8f1f52836a977eb7071e6c512"
+  integrity sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==
 
 "@inquirer/input@^4.3.1":
   version "4.3.1"
@@ -1327,6 +1393,14 @@
     "@inquirer/core" "^10.3.2"
     "@inquirer/type" "^3.0.10"
 
+"@inquirer/input@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/input/-/input-5.0.4.tgz#56a839a27ed091972f0eb6be1ed6ede2f7f4223f"
+  integrity sha512-4B3s3jvTREDFvXWit92Yc6jF1RJMDy2VpSqKtm4We2oVU65YOh2szY5/G14h4fHlyQdpUmazU5MPCFZPRJ0AOw==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
+
 "@inquirer/number@^3.0.23":
   version "3.0.23"
   resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-3.0.23.tgz#3fdec2540d642093fd7526818fd8d4bdc7335094"
@@ -1334,6 +1408,14 @@
   dependencies:
     "@inquirer/core" "^10.3.2"
     "@inquirer/type" "^3.0.10"
+
+"@inquirer/number@^4.0.4":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/number/-/number-4.0.4.tgz#c0ea5cd3a3f5e15ea1e90d6144abfd338a07f4f7"
+  integrity sha512-CmMp9LF5HwE+G/xWsC333TlCzYYbXMkcADkKzcawh49fg2a1ryLc7JL1NJYYt1lJ+8f4slikNjJM9TEL/AljYQ==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/password@^4.0.23":
   version "4.0.23"
@@ -1343,6 +1425,15 @@
     "@inquirer/ansi" "^1.0.2"
     "@inquirer/core" "^10.3.2"
     "@inquirer/type" "^3.0.10"
+
+"@inquirer/password@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/password/-/password-5.0.4.tgz#d691b1e9f4cc323ffff94579db040c751140c4fa"
+  integrity sha512-ZCEPyVYvHK4W4p2Gy6sTp9nqsdHQCfiPXIP9LbJVW4yCinnxL/dDDmPaEZVysGrj8vxVReRnpfS2fOeODe9zjg==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/prompts@^7.8.6":
   version "7.10.1"
@@ -1360,6 +1451,22 @@
     "@inquirer/search" "^3.2.2"
     "@inquirer/select" "^4.4.2"
 
+"@inquirer/prompts@^8.2.0":
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/prompts/-/prompts-8.2.0.tgz#864494037fe3d456a829198a0563b17492b95a77"
+  integrity sha512-rqTzOprAj55a27jctS3vhvDDJzYXsr33WXTjODgVOru21NvBo9yIgLIAf7SBdSV0WERVly3dR6TWyp7ZHkvKFA==
+  dependencies:
+    "@inquirer/checkbox" "^5.0.4"
+    "@inquirer/confirm" "^6.0.4"
+    "@inquirer/editor" "^5.0.4"
+    "@inquirer/expand" "^5.0.4"
+    "@inquirer/input" "^5.0.4"
+    "@inquirer/number" "^4.0.4"
+    "@inquirer/password" "^5.0.4"
+    "@inquirer/rawlist" "^5.2.0"
+    "@inquirer/search" "^4.1.0"
+    "@inquirer/select" "^5.0.4"
+
 "@inquirer/rawlist@^4.1.11":
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-4.1.11.tgz#313c8c3ffccb7d41e990c606465726b4a898a033"
@@ -1368,6 +1475,14 @@
     "@inquirer/core" "^10.3.2"
     "@inquirer/type" "^3.0.10"
     yoctocolors-cjs "^2.1.3"
+
+"@inquirer/rawlist@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/rawlist/-/rawlist-5.2.0.tgz#fee7d58867508781ff96483f5894bfdd551a1ec2"
+  integrity sha512-CciqGoOUMrFo6HxvOtU5uL8fkjCmzyeB6fG7O1vdVAZVSopUBYECOwevDBlqNLyyYmzpm2Gsn/7nLrpruy9RFg==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/search@^3.2.2":
   version "3.2.2"
@@ -1378,6 +1493,15 @@
     "@inquirer/figures" "^1.0.15"
     "@inquirer/type" "^3.0.10"
     yoctocolors-cjs "^2.1.3"
+
+"@inquirer/search@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@inquirer/search/-/search-4.1.0.tgz#5e17b5787975b8b4df182ca969e525c01c98dc4f"
+  integrity sha512-EAzemfiP4IFvIuWnrHpgZs9lAhWDA0GM3l9F4t4mTQ22IFtzfrk8xbkMLcAN7gmVML9O/i+Hzu8yOUyAaL6BKA==
+  dependencies:
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
 
 "@inquirer/select@^4.4.2":
   version "4.4.2"
@@ -1390,10 +1514,25 @@
     "@inquirer/type" "^3.0.10"
     yoctocolors-cjs "^2.1.3"
 
+"@inquirer/select@^5.0.4":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@inquirer/select/-/select-5.0.4.tgz#11249c7091946681d394f649b00844f8fda38d7a"
+  integrity sha512-s8KoGpPYMEQ6WXc0dT9blX2NtIulMdLOO3LA1UKOiv7KFWzlJ6eLkEYTDBIi+JkyKXyn8t/CD6TinxGjyLt57g==
+  dependencies:
+    "@inquirer/ansi" "^2.0.3"
+    "@inquirer/core" "^11.1.1"
+    "@inquirer/figures" "^2.0.3"
+    "@inquirer/type" "^4.0.3"
+
 "@inquirer/type@^3.0.10", "@inquirer/type@^3.0.7":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-3.0.10.tgz#11ed564ec78432a200ea2601a212d24af8150d50"
   integrity sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==
+
+"@inquirer/type@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@inquirer/type/-/type-4.0.3.tgz#219b8c29afe366067f90705d156d1b395c9e2af0"
+  integrity sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==
 
 "@isaacs/balanced-match@^4.0.1":
   version "4.0.1"
@@ -5990,6 +6129,11 @@ ansi-styles@^6.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
+ansi-styles@^6.2.1:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
 anymatch@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -7622,6 +7766,11 @@ emittery@^0.13.1:
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.13.1.tgz#c04b8c3457490e0847ae51fced3af52d338e3dad"
   integrity sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==
 
+emoji-regex@^10.3.0:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
+  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -8088,6 +8237,11 @@ etag@^1.8.1, etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
+
+eventemitter3@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-2.0.3.tgz#b5e1079b59fb5e1ba2771c0a993be060a58c99ba"
+  integrity sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg==
 
 eventemitter3@^4.0.4:
   version "4.0.7"
@@ -8574,6 +8728,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-east-asian-width@^1.0.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.4.0.tgz#9bc4caa131702b4b61729cb7e42735bc550c9ee6"
+  integrity sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==
 
 get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4, get-intrinsic@^1.2.5, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -9120,7 +9279,7 @@ iconv-lite@0.6.3, iconv-lite@^0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+iconv-lite@^0.7.0, iconv-lite@^0.7.2, iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.7.2.tgz#d0bdeac3f12b4835b7359c2ad89c422a4d1cc72e"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
@@ -11394,6 +11553,11 @@ mute-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-2.0.0.tgz#a5446fc0c512b71c83c44d908d5c7b7b4c493b2b"
   integrity sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==
 
+mute-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-3.0.0.tgz#cd8014dd2acb72e1e91bb67c74f0019e620ba2d1"
+  integrity sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==
+
 nanoid@^3.3.8:
   version "3.3.8"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
@@ -13618,7 +13782,7 @@ string-length@^4.0.2:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -13636,15 +13800,6 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
@@ -13653,6 +13808,15 @@ string-width@^5.0.1, string-width@^5.1.2:
     eastasianwidth "^0.2.0"
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
+
+string-width@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
+  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
+  dependencies:
+    emoji-regex "^10.3.0"
+    get-east-asian-width "^1.0.0"
+    strip-ansi "^7.1.0"
 
 string.prototype.matchall@^4.0.11:
   version "4.0.11"
@@ -13735,7 +13899,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13756,17 +13920,17 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
 strip-ansi@^7.0.1:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
   integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
+
+strip-ansi@^7.1.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.2.tgz#132875abde678c7ea8d691533f2e7e22bb744dba"
+  integrity sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==
   dependencies:
     ansi-regex "^6.0.1"
 
@@ -14897,7 +15061,7 @@ workerpool@^6.5.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.5.1.tgz#060f73b39d0caf97c6db64da004cd01b4c099544"
   integrity sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -14924,15 +15088,6 @@ wrap-ansi@^6.2.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
@@ -14941,6 +15096,15 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+wrap-ansi@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
+  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
+  dependencies:
+    ansi-styles "^6.2.1"
+    string-width "^7.0.0"
+    strip-ansi "^7.1.0"
 
 wrappy@1:
   version "1.0.2"
@@ -14980,6 +15144,13 @@ wsrun@^5.2.4:
     throat "^4.1.0"
     yargs "^13.0.0"
 
+xml-lexer@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xml-lexer/-/xml-lexer-0.2.2.tgz#518193a4aa334d58fc7d248b549079b89907e046"
+  integrity sha512-G0i98epIwiUEiKmMcavmVdhtymW+pCAohMRgybyIME9ygfVu8QheIi+YoQh3ngiThsT0SQzJT4R0sKDEv8Ou0w==
+  dependencies:
+    eventemitter3 "^2.0.0"
+
 xml-name-validator@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
@@ -14989,6 +15160,14 @@ xml-name-validator@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
   integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xml-reader@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/xml-reader/-/xml-reader-2.4.3.tgz#9f810caf7c425a5aafb848b1c45103c9e71d7530"
+  integrity sha512-xWldrIxjeAMAu6+HSf9t50ot1uL5M+BtOidRCWHXIeewvSeIpscWCsp4Zxjk8kHHhdqFBrfK8U0EJeCcnyQ/gA==
+  dependencies:
+    eventemitter3 "^2.0.0"
+    xml-lexer "^0.2.2"
 
 xmlchars@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
Add the "import dissemination blocks" task to Localisation so we can import all the zone boundaries and proximity indices in the Localisation database.

This is mostly copied code from Transition. We also do not import the population into the census table, as there is no need for it for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import dissemination block boundaries from GML geographic files.
  * Import proximity measures (location indices) from CSV files.
  * Interactive prompts and file selection to guide import workflows.
  * Option to reset, recreate, and re-import existing datasets.
  * New runnable tasks/scripts to execute and automate the import processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->