### PR TITLE
car prediction: return both the predicted and current number

### DIFF
--- a/localisation/src/survey/calculations/__tests__/index.test.ts
+++ b/localisation/src/survey/calculations/__tests__/index.test.ts
@@ -6,6 +6,7 @@
  */
 import _cloneDeep from 'lodash/cloneDeep';
 import config from 'chaire-lib-common/lib/config/shared/project.config';
+import * as Status from 'chaire-lib-common/lib/utils/Status';
 import { calculateAccessibilityAndRouting, calculateMonthlyCost } from '../index';
 import { Address, AddressAccessibilityMapsDurations, Destination, RoutingByModeDistanceAndTime } from '../../common/types';
 import { InterviewAttributes } from 'evolution-common/lib/services/questionnaire/types';
@@ -55,7 +56,7 @@ describe('calculateMonthlyCost', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         // Keep tests deterministic: by default, assume no predicted cars.
-        mockPredictCarOwnership.mockResolvedValue(0);
+        mockPredictCarOwnership.mockResolvedValue(Status.createOk(0));
     });
 
     describe('Rent scenarios', () => {
@@ -416,6 +417,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBe(0);
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBe(1200);
+            expect(result.currentNumberOfVehicles).toBe(0);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return carCostMonthly as 0 when vehicles field is undefined', async () => {
@@ -435,6 +438,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBe(0);
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBe(1200);
+            expect(result.currentNumberOfVehicles).toBe(0);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should calculate carCostMonthly correctly for one vehicle', async () => {
@@ -455,7 +460,7 @@ describe('calculateMonthlyCost', () => {
                     engineType: 'electric' as any
                 }
             };
-            mockPredictCarOwnership.mockResolvedValueOnce(1);
+            mockPredictCarOwnership.mockResolvedValueOnce(Status.createOk(1));
 
             const result = await calculateMonthlyCost(address, interviewOneVehicle);
 
@@ -465,6 +470,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeGreaterThan(1690);
             expect(result.totalCostMonthly).toBeLessThan(1700);
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(1);
         });
 
         it('should calculate carCostMonthly correctly for three vehicles', async () => {
@@ -497,7 +504,7 @@ describe('calculateMonthlyCost', () => {
                     engineType: 'electric' as any
                 }
             };
-            mockPredictCarOwnership.mockResolvedValueOnce(3);
+            mockPredictCarOwnership.mockResolvedValueOnce(Status.createOk(3));
 
             const result = await calculateMonthlyCost(address, interviewThreeVehicles);
 
@@ -508,6 +515,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.housingCostMonthly).toBe(1500);
             expect(result.totalCostMonthly).toBeGreaterThan(3700);
             expect(result.totalCostMonthly).toBeLessThan(3900);
+            expect(result.currentNumberOfVehicles).toBe(3);
+            expect(result.predictedNumberOfVehicles).toBe(3);
         });
 
         it('should return null carCostMonthly when vehicle has missing category', async () => {
@@ -534,6 +543,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return null carCostMonthly when vehicle has missing engineType', async () => {
@@ -560,6 +571,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return null carCostMonthly when vehicle has unknown category', async () => {
@@ -586,6 +599,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return null carCostMonthly when vehicle has unknown engineType', async () => {
@@ -612,6 +627,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return null carCostMonthly when vehicle combination is not available', async () => {
@@ -638,6 +655,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should return null carCostMonthly when one vehicle out of many has missing data', async () => {
@@ -676,6 +695,8 @@ describe('calculateMonthlyCost', () => {
             expect(result.carCostMonthly).toBeNull();
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeNull();
+            expect(result.currentNumberOfVehicles).toBe(3);
+            expect(result.predictedNumberOfVehicles).toBe(0);
         });
 
         it('should handle vehicles with nicknames', async () => {
@@ -697,7 +718,7 @@ describe('calculateMonthlyCost', () => {
                     engineType: 'electric' as any
                 }
             };
-            mockPredictCarOwnership.mockResolvedValueOnce(1);
+            mockPredictCarOwnership.mockResolvedValueOnce(Status.createOk(1));
 
             const result = await calculateMonthlyCost(address, interviewWithNickname);
 
@@ -706,6 +727,85 @@ describe('calculateMonthlyCost', () => {
             expect(result.housingCostMonthly).toBe(1200);
             expect(result.totalCostMonthly).toBeGreaterThan(1690);
             expect(result.totalCostMonthly).toBeLessThan(1700);
+            expect(result.currentNumberOfVehicles).toBe(1);
+            expect(result.predictedNumberOfVehicles).toBe(1);
+        });
+
+        it('should calculate carCostMonthly with prediction and average cost when it differs from current vehicle count', async () => {
+            const address: Address = {
+                _sequence: 1,
+                _uuid: 'address-1',
+                ownership: 'rent',
+                rentMonthly: 1500,
+                areUtilitiesIncluded: true
+            };
+
+            // Household has 3 cars
+            const interviewThreeVehicles = _cloneDeep(mockInterview);
+            interviewThreeVehicles.response.cars = {
+                'car-1': {
+                    _sequence: 1,
+                    _uuid: 'car-1',
+                    category: 'passengerCar' as any,
+                    engineType: 'gas' as any
+                },
+                'car-2': {
+                    _sequence: 2,
+                    _uuid: 'car-2',
+                    category: 'suv' as any,
+                    engineType: 'hybrid' as any
+                },
+                'car-3': {
+                    _sequence: 3,
+                    _uuid: 'car-3',
+                    category: 'pickup' as any,
+                    engineType: 'electric' as any
+                }
+            };
+            // Predict 1 car
+            mockPredictCarOwnership.mockResolvedValueOnce(Status.createOk(1));
+
+            const result = await calculateMonthlyCost(address, interviewThreeVehicles);
+
+            // Sum of costs: passengerCar/gas (~9399) + suv/hybrid (~7831) + pickup/electric (~10440) = ~27670/year = ~2305/month, for one vehicle / 3 = ~768/month
+            expect(result.carCostMonthly).not.toBeNull();
+            expect(result.carCostMonthly).toBeGreaterThan(760);
+            expect(result.carCostMonthly).toBeLessThan(770);
+            expect(result.housingCostMonthly).toBe(1500);
+            expect(result.totalCostMonthly).toBeGreaterThan(2260);
+            expect(result.totalCostMonthly).toBeLessThan(2270);
+            expect(result.currentNumberOfVehicles).toBe(3);
+            expect(result.predictedNumberOfVehicles).toBe(1);
+        });
+
+        it('should calculate carCostMonthly with default average if car predicted, but no current car', async () => {
+            const address: Address = {
+                _sequence: 1,
+                _uuid: 'address-1',
+                ownership: 'rent',
+                rentMonthly: 1500,
+                areUtilitiesIncluded: true
+            };
+
+            // Household has no cars currently
+            const interviewNoVehicles = _cloneDeep(mockInterview);
+            interviewNoVehicles.response.cars = {
+        
+            };
+            // Predict 1 car
+            mockPredictCarOwnership.mockResolvedValueOnce(Status.createOk(1));
+
+            const result = await calculateMonthlyCost(address, interviewNoVehicles);
+
+            // average is 9399.17$/year (passengerCar/gas) = 783,25$/month
+            expect(result.carCostMonthly).not.toBeNull();
+            expect(result.carCostMonthly).toBeGreaterThan(780);
+            expect(result.carCostMonthly).toBeLessThan(790);
+            expect(result.housingCostMonthly).toBe(1500);
+            expect(result.totalCostMonthly).toBeGreaterThan(2280);
+            expect(result.totalCostMonthly).toBeLessThan(2290);
+            expect(result.currentNumberOfVehicles).toBe(0);
+            expect(result.predictedNumberOfVehicles).toBe(1);
         });
     });
 });

--- a/localisation/src/survey/common/types.ts
+++ b/localisation/src/survey/common/types.ts
@@ -26,7 +26,7 @@ export type Address = {
     taxesYearly?: number;
     // Monthly utilities cost
     utilitiesMonthly?: number;
-    monthlyCost?: CalculationResults;
+    monthlyCost?: CostsCalculationResults;
     accessibilityMapsByMode?:
         | {
               walking: AddressAccessibilityMapsDurations | null;
@@ -104,7 +104,7 @@ export type Vehicle = {
     engineType?: CarEngine;
 };
 
-export type CalculationResults = {
+export type CostsCalculationResults = {
     /** Monthly cost for housing. Can be null if there is missing information */
     housingCostMonthly: number | null;
     /** Percentage of income spent on housing and transport. Can be null if there is missing information */
@@ -113,6 +113,10 @@ export type CalculationResults = {
     carCostMonthly: number | null;
     /** Precomputed total, only if both housing and car costs are available, null otherwise */
     totalCostMonthly: number | null;
+    /** Current number of vehicles in the household. Can be null if there is missing information */
+    currentNumberOfVehicles: number | null;
+    /** Predicted number of vehicles in the household. Can be null if it was not possible to predict */
+    predictedNumberOfVehicles: number | null;
 };
 
 // Type for the destination result object in the results template

--- a/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
+++ b/localisation/src/survey/server/__tests__/serverFieldUpdate.test.ts
@@ -168,7 +168,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 350,
-                totalCostMonthly: 1550
+                totalCostMonthly: 1550,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
 
             const interview = createMockInterview({ 'address-1': address });
@@ -181,7 +183,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 350,
-                totalCostMonthly: 1550
+                totalCostMonthly: 1550,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
             expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
             expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual('calculating');
@@ -224,7 +228,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 2244.81,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 450,
-                totalCostMonthly: 2694.81
+                totalCostMonthly: 2694.81,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
 
             const interview = createMockInterview({ 'address-1': address });
@@ -237,6 +243,8 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBeLessThan(2300);
             expect(result['addresses.address-1.monthlyCost'].housingAndTransportCostPercentageOfIncome).toBeNull();
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(450);
+            expect(result['addresses.address-1.monthlyCost'].currentNumberOfVehicles).toBe(1);
+            expect(result['addresses.address-1.monthlyCost'].predictedNumberOfVehicles).toBe(1);
             expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
             expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual('calculating');
             expect(result['addresses.address-1.routingTimeDistances']).toEqual('calculating');
@@ -295,13 +303,17 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                     housingCostMonthly: 1200,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 300,
-                    totalCostMonthly: 1500
+                    totalCostMonthly: 1500,
+                    currentNumberOfVehicles: null,
+                    predictedNumberOfVehicles: null
                 })
                 .mockResolvedValueOnce({
                     housingCostMonthly: 1650,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 400,
-                    totalCostMonthly: 2050
+                    totalCostMonthly: 2050,
+                    currentNumberOfVehicles: null,
+                    predictedNumberOfVehicles: 1
                 });
 
             const interview = createMockInterview({
@@ -319,8 +331,12 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
 
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBe(1200);
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(300);
+            expect(result['addresses.address-1.monthlyCost'].currentNumberOfVehicles).toBeNull();
+            expect(result['addresses.address-1.monthlyCost'].predictedNumberOfVehicles).toBeNull();
             expect(result['addresses.address-2.monthlyCost'].housingCostMonthly).toBe(1650);
             expect(result['addresses.address-2.monthlyCost'].carCostMonthly).toBe(400);
+            expect(result['addresses.address-2.monthlyCost'].currentNumberOfVehicles).toBeNull();
+            expect(result['addresses.address-2.monthlyCost'].predictedNumberOfVehicles).toBe(1);
             expect(result['addresses.address-1.accessibilityMapsByMode']).toEqual('calculating');
             expect(result['addresses.address-2.accessibilityMapsByMode']).toEqual('calculating');
             expect(result['addresses.address-1.routingTimeDistances']).toEqual('calculating');
@@ -377,13 +393,17 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                     housingCostMonthly: 1200,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 310,
-                    totalCostMonthly: 1510
+                    totalCostMonthly: 1510,
+                    currentNumberOfVehicles: 0,
+                    predictedNumberOfVehicles: 0
                 })
                 .mockResolvedValueOnce({
                     housingCostMonthly: null,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: null,
-                    totalCostMonthly: null
+                    totalCostMonthly: null,
+                    currentNumberOfVehicles: null,
+                    predictedNumberOfVehicles: null
                 });
 
             mockCalculateAccessibilityAndRouting.mockResolvedValue({
@@ -401,8 +421,12 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
 
             expect(result['addresses.address-1.monthlyCost'].housingCostMonthly).toBe(1200);
             expect(result['addresses.address-1.monthlyCost'].carCostMonthly).toBe(310);
+            expect(result['addresses.address-1.monthlyCost'].currentNumberOfVehicles).toBe(0);
+            expect(result['addresses.address-1.monthlyCost'].predictedNumberOfVehicles).toBe(0);
             expect(result['addresses.address-2.monthlyCost'].housingCostMonthly).toBeNull();
             expect(result['addresses.address-2.monthlyCost'].carCostMonthly).toBeNull();
+            expect(result['addresses.address-2.monthlyCost'].currentNumberOfVehicles).toBeNull();
+            expect(result['addresses.address-2.monthlyCost'].predictedNumberOfVehicles).toBeNull();
             expect('addresses.address-1.accessibilityMapsByMode' in result).toBe(true);
             expect('addresses.address-2.accessibilityMapsByMode' in result).toBe(true);
             expect('addresses.address-1.routingTimeDistances' in result).toBe(true);
@@ -440,7 +464,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 2244.81,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 450,
-                totalCostMonthly: 2694.81
+                totalCostMonthly: 2694.81,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 2
             });
 
             const interview = createMockInterview({ 'address-1': address });
@@ -537,7 +563,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 250,
-                totalCostMonthly: 1450
+                totalCostMonthly: 1450,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
 
             const interview = createMockInterview({ 'address-1': address });
@@ -613,13 +641,17 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                     housingCostMonthly: 1200,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 330,
-                    totalCostMonthly: 1530
+                    totalCostMonthly: 1530,
+                    currentNumberOfVehicles: 1,
+                    predictedNumberOfVehicles: 1
                 })
                 .mockResolvedValueOnce({
                     housingCostMonthly: null,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: null,
-                    totalCostMonthly: null
+                    totalCostMonthly: null,
+                    currentNumberOfVehicles: null,
+                    predictedNumberOfVehicles: null
                 });
 
             const interview = createMockInterview({
@@ -662,13 +694,17 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                     housingCostMonthly: 1200,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 290,
-                    totalCostMonthly: 1490
+                    totalCostMonthly: 1490,
+                    currentNumberOfVehicles: 1,
+                    predictedNumberOfVehicles: 1
                 })
                 .mockResolvedValueOnce({
                     housingCostMonthly: 1100,
                     housingAndTransportCostPercentageOfIncome: null,
                     carCostMonthly: 270,
-                    totalCostMonthly: 1370
+                    totalCostMonthly: 1370,
+                    currentNumberOfVehicles: 1,
+                    predictedNumberOfVehicles: 1
                 });
 
             // Add them out of order
@@ -718,7 +754,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: null,
-                totalCostMonthly: null
+                totalCostMonthly: null,
+                currentNumberOfVehicles: null,
+                predictedNumberOfVehicles: null
             });
 
             mockCalculateAccessibilityAndRouting.mockResolvedValue({
@@ -770,7 +808,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 320,
-                totalCostMonthly: 1520
+                totalCostMonthly: 1520,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
 
             mockCalculateAccessibilityAndRouting.mockRejectedValue(new Error('Accessibility service error'));
@@ -786,7 +826,9 @@ describe('serverFieldUpdate - _sections._actions callback', () => {
                 housingCostMonthly: 1200,
                 housingAndTransportCostPercentageOfIncome: null,
                 carCostMonthly: 320,
-                totalCostMonthly: 1520
+                totalCostMonthly: 1520,
+                currentNumberOfVehicles: 1,
+                predictedNumberOfVehicles: 1
             });
 
             // Validate register update callback call


### PR DESCRIPTION
Also make sure to display the cost of the current situation if the prediction model does not work (no data or other errors).

The predicted number of cars will be `null` if the calculation did not work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visibility of current and predicted vehicle counts in cost calculations.
  * Expanded accessibility analysis to include cycling, driving, and transit options alongside walking.

* **Improvements**
  * Enhanced car ownership prediction with more robust error handling and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->